### PR TITLE
map: use difficultyName directly

### DIFF
--- a/map/map_page.css
+++ b/map/map_page.css
@@ -30,11 +30,11 @@
     width: min(100%, calc(gridBaseline * 100));
 }
 
-.complexities {
+.difficulties {
     display: flex;
     margin: gridBaseline calc(-1 * gridBaseline);
 }
-.complexityPill {
+.difficultyPill {
     background: colorGrey;
     margin: 0 gridBaseline;
     padding: calc(gridBaseline * 0.5) calc(gridBaseline * 2);

--- a/map/map_page.tsx
+++ b/map/map_page.tsx
@@ -1,41 +1,43 @@
 import { T } from 'pages/paradb/base/text/text';
 import { Button } from 'pages/paradb/base/ui/button/button';
 import { getMapFileLink } from 'pages/paradb/utils/maps';
-import { Complexity, PDMap } from 'paradb-api-schema';
+import { Difficulty, PDMap } from 'paradb-api-schema';
 import React from 'react';
 import styles from './map_page.css';
 
 type Props = { map: PDMap | undefined, canDelete: boolean, deleteMap(): void };
 
-function getComplexityNameDefault(complexity: number) {
-  switch (complexity) {
-    case 1:
-      return 'Easy';
-    case 2:
-      return 'Medium';
-    case 3:
-      return 'Hard';
-    case 4:
-      return 'Expert';
-    case 5:
-      return 'Expert+';
+export function getDifficultyColor(difficultyName: string | undefined) {
+  if (difficultyName == null) {
+    return 'black';
+  }
+  switch (difficultyName.toLowerCase()) {
+    case 'easy':
+      return 'green';
+    case 'medium':
+      return 'yellow';
+    case 'hard':
+      return 'orange';
+    case 'expert':
+      return 'red';
     default:
-      throw new Error(`Did not expect complexity level ${complexity}`);
+      // Custom difficulty name -- we don't know the difficulty level.
+      // TODO: could do some difficulty name parsing to see if it has easy / medium / hard in the name.
+      return 'black';
   }
 }
 
-const ComplexityPills = (props: { complexities: Complexity[] }) => (
-  <div className={styles.complexities}>
+const DifficultyPills = (props: { difficulties: Difficulty[] }) => (
+  <div className={styles.difficulties}>
     {props
-      .complexities
-      .map((c, i) => (
+      .difficulties
+      .map((d, i) => (
         <div
           key={i}
-          className={styles.complexityPill}
+          className={styles.difficultyPill}
+          style={{ backgroundColor: getDifficultyColor(d.difficultyName) }}
         >
-          <T.Small color="white">
-            {c.complexityName || getComplexityNameDefault(c.complexity)}
-          </T.Small>
+          <T.Small color="white">{d.difficultyName || 'Unknown'}</T.Small>
         </div>
       ))}
   </div>
@@ -73,7 +75,7 @@ export class MapPage extends React.Component<Props> {
               ? <>| mapped by {map.author}</>
               : undefined}
           </T.Medium>
-          <ComplexityPills complexities={map.complexities}/>
+          <DifficultyPills difficulties={map.difficulties}/>
           {map.description != null
             ? (
               <div className={styles.description}>

--- a/map_list/create.tsx
+++ b/map_list/create.tsx
@@ -7,7 +7,7 @@ import { Api } from 'pages/paradb/base/api/api';
 import metrics from 'pages/paradb/base/metrics/metrics.css';
 import { RouteLink } from 'pages/paradb/base/text/link';
 import { T } from 'pages/paradb/base/text/text';
-import { ComplexityColorPills, MapList } from 'pages/paradb/map_list/map_list';
+import { DifficultyColorPills, MapList } from 'pages/paradb/map_list/map_list';
 import { MapListPresenter, MapListStore } from 'pages/paradb/map_list/map_list_presenter';
 import { routeFor, RoutePath } from 'pages/paradb/router/routes';
 import { PDMap, serializeMap } from 'paradb-api-schema';
@@ -59,7 +59,7 @@ export function createMapList(api: Api) {
         React.memo(() => wrapWithMapRoute(<T.Small>{map.title}</T.Small>)),
         React.memo(() => wrapWithMapRoute(<T.Small>{map.artist}</T.Small>)),
         React.memo(() => wrapWithMapRoute(<T.Small>{map.author}</T.Small>)),
-        React.memo(() => wrapWithMapRoute(<ComplexityColorPills complexities={map.complexities}/>)),
+        React.memo(() => wrapWithMapRoute(<DifficultyColorPills difficulties={map.difficulties}/>)),
         React.memo(() =>
           wrapWithMapRoute(
             <T.Small>{formatDate(map.submissionDate)}</T.Small>,
@@ -81,7 +81,7 @@ export function createMapList(api: Api) {
       { content: <T.Small weight="bold">Mapper</T.Small>, sort: naturalSort(m => m.author) },
       {
         content: <T.Small weight="bold">Difficulties</T.Small>,
-        sort: naturalSort(m => m.complexities.map(c => c.complexityName).join()),
+        sort: naturalSort(m => m.difficulties.map(c => c.difficultyName).join()),
         width: `calc(${metrics.gridBaseline} * 13)`,
       },
       {

--- a/map_list/map_list.css
+++ b/map_list/map_list.css
@@ -73,12 +73,12 @@
     justify-content: center;
 }
 
-.complexities {
+.difficulties {
     display: flex;
     gap: gridBaseline;
 }
 
-.complexityColorPill {
+.difficultyColorPill {
     width: calc(gridBaseline * 2);
     height: calc(gridBaseline * 2);
     border-radius: 50%;

--- a/map_list/map_list.tsx
+++ b/map_list/map_list.tsx
@@ -2,7 +2,8 @@ import classNames from 'classnames';
 import { observer } from 'mobx-react';
 import { Button } from 'pages/paradb/base/ui/button/button';
 import { Textbox } from 'pages/paradb/base/ui/textbox/textbox';
-import { Complexity } from 'paradb-api-schema';
+import { getDifficultyColor } from 'pages/paradb/map/map_page';
+import { Difficulty } from 'paradb-api-schema';
 import React from 'react';
 import styles from './map_list.css';
 
@@ -18,32 +19,15 @@ type Props = {
   onChangeFilterQuery(val: string): void,
 };
 
-function getComplexityColor(complexity: number) {
-  switch (complexity) {
-    case 1:
-      return 'green';
-    case 2:
-      return 'yellow';
-    case 3:
-      return 'orange';
-    case 4:
-      return 'red';
-    case 5:
-      return 'black';
-    default:
-      throw new Error(`Did not expect complexity level ${complexity}`);
-  }
-}
-
-export const ComplexityColorPills = (props: { complexities: Complexity[] }) => (
-  <div className={styles.complexities}>
+export const DifficultyColorPills = (props: { difficulties: Difficulty[] }) => (
+  <div className={styles.difficulties}>
     {props
-      .complexities
-      .map((c, i) => (
+      .difficulties
+      .map((d, i) => (
         <div
           key={i}
-          className={styles.complexityColorPill}
-          style={{ backgroundColor: getComplexityColor(c.complexity) }}
+          className={styles.difficultyColorPill}
+          style={{ backgroundColor: getDifficultyColor(d.difficultyName) }}
         >
         </div>
       ))}


### PR DESCRIPTION
After https://github.com/bitnimble/paradb-api/pull/3, we can now use `difficultyName` directly rather than doing a number -> name mapping. This PR just updates it to do so (and adds name -> color mapping as a result)